### PR TITLE
Fix bug with maxWidth_

### DIFF
--- a/DeviceAdapters/Basler/BaslerPylon6Camera.cpp
+++ b/DeviceAdapters/Basler/BaslerPylon6Camera.cpp
@@ -304,9 +304,11 @@ int BaslerCamera::Initialize()
 		//Sensor size
 		nodeMap_ = &camera_->GetNodeMap();
 		const CIntegerPtr width = nodeMap_->GetNode("Width");
-		maxWidth_ = (unsigned int) width->GetMax();
+		// maxWidth_ = (unsigned int) width->GetMax();
+		maxWidth_ = (unsigned int) CIntegerPtr(nodeMap_->GetNode("WidthMax"))->GetValue();
 		const CIntegerPtr height = nodeMap_->GetNode("Height");
-		maxHeight_ = (unsigned int) height->GetMax();
+		// maxHeight_ = (unsigned int) height->GetMax();
+		maxHeight_ = (unsigned int) CIntegerPtr(nodeMap_->GetNode("HeightMax"))->GetValue();
 
 
 		if(IsAvailable(width))


### PR DESCRIPTION
If camera is initialized with smaller ROI, maxWidth will not be computed correctly. New implementation uses built-in `WidthMax` property. Same for maxHeight